### PR TITLE
fix(deps): update xorq GitHub hash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ typing-extensions==4.14.1
 tzdata==2025.2
 urllib3==2.5.0
 wcwidth==0.2.13
-xorq @ git+https://github.com/xorq-labs/xorq@7d4c0328d7daf8341f8a3cfb65a4c944d37056ff
+xorq @ git+https://github.com/xorq-labs/xorq@319eaf14a5879a057594fee8e1c2693a9bbc0a3d
 xorq-datafusion==0.2.3
 xxhash==3.5.0
 yarl==1.20.1


### PR DESCRIPTION
The api for train_test_splits change and now a unique_key is not required. The code was updated but the dependency no.